### PR TITLE
Stacks: Eliminate 'latest' versions and use Docker volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .git
 .vscode
-data
 node_modules
 *.env

--- a/stacks/keepalived.yml
+++ b/stacks/keepalived.yml
@@ -1,22 +1,22 @@
 version: '3.7'
 
 services:
-    keepalived:
-        image: lolhens/keepalived-swarm:latest
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
-            - /usr/bin/docker:/usr/bin/docker:ro
-        networks:
-            - host
-        deploy:
-            mode: global
-            placement:
-                constraints: [node.role == manager]
-        environment:
-            KEEPALIVED_INTERFACE: enp0s1
-        env_file: keepalived.env
+   keepalived:
+      image: lolhens/keepalived-swarm:latest
+      volumes:
+         - /var/run/docker.sock:/var/run/docker.sock
+         - /usr/bin/docker:/usr/bin/docker:ro
+      networks:
+         - host
+      deploy:
+         mode: global
+         placement:
+            constraints: [node.role == manager]
+      environment:
+         KEEPALIVED_INTERFACE: enp0s1
+      env_file: keepalived.env
 
 networks:
-    host:
-        external: true
-        name: host
+   host:
+      external: true
+      name: host

--- a/stacks/keepalived.yml
+++ b/stacks/keepalived.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
    keepalived:
-      image: lolhens/keepalived-swarm:latest
+      image: lolhens/keepalived-swarm:0.2.3
       volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - /usr/bin/docker:/usr/bin/docker:ro

--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -8,9 +8,6 @@ echo '
 '
 sleep 2
 scr_dir="${0%/*}"
-mkdir -p "$scr_dir"/../data/nginxproxymanager/data
-mkdir -p "$scr_dir"/../data/nginxproxymanager/db
-mkdir -p "$scr_dir"/../data/nginxproxymanager/letsencrypt
 [ -z "$(docker network ls -qf name=frontend)" ] && docker network create -d overlay --scope swarm --attachable frontend
 [ -z "$(docker secret ls -qf name=nginxproxymanager_db_password)" ] && openssl rand -base64 32 | docker secret create nginxproxymanager_db_password -
 [ -z "$(docker secret ls -qf name=nginxproxymanager_db_root_password)" ] && openssl rand -base64 32 | docker secret create nginxproxymanager_db_root_password -

--- a/stacks/nginx-proxy-manager.yml
+++ b/stacks/nginx-proxy-manager.yml
@@ -31,8 +31,8 @@ services:
          DB_MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
          DB_MYSQL_NAME: 'npm'
       volumes:
-         - '../data/nginxproxymanager/data:/data'
-         - '../data/nginxproxymanager/letsencrypt:/etc/letsencrypt'
+         - 'data:/data'
+         - 'letsencrypt:/etc/letsencrypt'
       secrets:
          - nginxproxymanager_db_password
       networks:
@@ -50,9 +50,14 @@ services:
          MYSQL_USER: 'npm'
          MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
       volumes:
-         - '../data/nginxproxymanager/db:/var/lib/mysql'
+         - 'db:/var/lib/mysql'
       secrets:
          - nginxproxymanager_db_password
          - nginxproxymanager_db_root_password
       networks:
          - backend
+
+volumes:
+   db:
+   data:
+   letsencrypt:

--- a/stacks/nginx-proxy-manager.yml
+++ b/stacks/nginx-proxy-manager.yml
@@ -1,58 +1,58 @@
 version: '3.1'
 
 networks:
-    frontend:
-        external: true
-    backend:
+   frontend:
+      external: true
+   backend:
 
 secrets:
-    nginxproxymanager_db_password:
-        external: true
-    nginxproxymanager_db_root_password:
-        external: true
+   nginxproxymanager_db_password:
+      external: true
+   nginxproxymanager_db_root_password:
+      external: true
 
 services:
 
-    app:
-        image: 'jc21/nginx-proxy-manager:latest'
-        depends_on:
-            - db
-        deploy:
-            mode: replicated
-            replicas: 1
-        ports:
-            - '80:80'
-            - '81:81'
-            - '443:443'
-        environment:
-            DB_MYSQL_HOST: 'db'
-            DB_MYSQL_PORT: 3306
-            DB_MYSQL_USER: 'npm'
-            DB_MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
-            DB_MYSQL_NAME: 'npm'
-        volumes:
-            - '../data/nginxproxymanager/data:/data'
-            - '../data/nginxproxymanager/letsencrypt:/etc/letsencrypt'
-        secrets:
-            - nginxproxymanager_db_password
-        networks:
-            - frontend
-            - backend
+   app:
+      image: 'jc21/nginx-proxy-manager:latest'
+      depends_on:
+         - db
+      deploy:
+         mode: replicated
+         replicas: 1
+      ports:
+         - '80:80'
+         - '81:81'
+         - '443:443'
+      environment:
+         DB_MYSQL_HOST: 'db'
+         DB_MYSQL_PORT: 3306
+         DB_MYSQL_USER: 'npm'
+         DB_MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
+         DB_MYSQL_NAME: 'npm'
+      volumes:
+         - '../data/nginxproxymanager/data:/data'
+         - '../data/nginxproxymanager/letsencrypt:/etc/letsencrypt'
+      secrets:
+         - nginxproxymanager_db_password
+      networks:
+         - frontend
+         - backend
 
-    db:
-        image: 'jc21/mariadb-aria:latest'
-        deploy:
-            mode: replicated
-            replicas: 1
-        environment:
-            MYSQL_ROOT_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_root_password
-            MYSQL_DATABASE: 'npm'
-            MYSQL_USER: 'npm'
-            MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
-        volumes:
-            - '../data/nginxproxymanager/db:/var/lib/mysql'
-        secrets:
-            - nginxproxymanager_db_password
-            - nginxproxymanager_db_root_password
-        networks:
-            - backend
+   db:
+      image: 'jc21/mariadb-aria:latest'
+      deploy:
+         mode: replicated
+         replicas: 1
+      environment:
+         MYSQL_ROOT_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_root_password
+         MYSQL_DATABASE: 'npm'
+         MYSQL_USER: 'npm'
+         MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
+      volumes:
+         - '../data/nginxproxymanager/db:/var/lib/mysql'
+      secrets:
+         - nginxproxymanager_db_password
+         - nginxproxymanager_db_root_password
+      networks:
+         - backend

--- a/stacks/nginx-proxy-manager.yml
+++ b/stacks/nginx-proxy-manager.yml
@@ -14,7 +14,7 @@ secrets:
 services:
 
    app:
-      image: 'jc21/nginx-proxy-manager:latest'
+      image: 'jc21/nginx-proxy-manager:2'
       depends_on:
          - db
       deploy:
@@ -40,7 +40,7 @@ services:
          - backend
 
    db:
-      image: 'jc21/mariadb-aria:latest'
+      image: 'jc21/mariadb-aria:10.4.15'
       deploy:
          mode: replicated
          replicas: 1

--- a/stacks/portainer-install.sh
+++ b/stacks/portainer-install.sh
@@ -8,6 +8,5 @@ echo '
 '
 sleep 2
 scr_dir="${0%/*}"
-mkdir -p "$scr_dir"/../data/portainer
 docker stack deploy -c "$scr_dir"/portainer.yml portainer
 echo Done installing Portainer!

--- a/stacks/portainer.yml
+++ b/stacks/portainer.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
 
    agent:
-      image: portainer/agent:latest
+      image: portainer/agent:2.19.1
       volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - /var/lib/docker/volumes:/var/lib/docker/volumes
@@ -15,7 +15,7 @@ services:
             constraints: [node.platform.os == linux]
 
    portainer:
-      image: 'portainer/portainer-ce:latest'
+      image: 'portainer/portainer-ce:2.19.1'
       command: -H tcp://tasks.agent:9001 --tlsskipverify
       ports:
          - '8000:8000'

--- a/stacks/portainer.yml
+++ b/stacks/portainer.yml
@@ -2,36 +2,36 @@ version: '3.2'
 
 services:
 
-    agent:
-        image: portainer/agent:latest
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
-            - /var/lib/docker/volumes:/var/lib/docker/volumes
-        networks:
-            - agent_network
-        deploy:
-            mode: global
-            placement:
-                constraints: [node.platform.os == linux]
+   agent:
+      image: portainer/agent:latest
+      volumes:
+         - /var/run/docker.sock:/var/run/docker.sock
+         - /var/lib/docker/volumes:/var/lib/docker/volumes
+      networks:
+         - agent_network
+      deploy:
+         mode: global
+         placement:
+            constraints: [node.platform.os == linux]
 
-    portainer:
-        image: 'portainer/portainer-ce:latest'
-        command: -H tcp://tasks.agent:9001 --tlsskipverify
-        ports:
-            - '8000:8000'
-            - '9000:9000'
-            - '9443:9443'
-        volumes:
-            - '../data/portainer:/data'
-        networks:
-            - agent_network
-        deploy:
-            mode: replicated
-            replicas: 1
-            placement:
-                constraints: [node.role == manager]
+   portainer:
+      image: 'portainer/portainer-ce:latest'
+      command: -H tcp://tasks.agent:9001 --tlsskipverify
+      ports:
+         - '8000:8000'
+         - '9000:9000'
+         - '9443:9443'
+      volumes:
+         - '../data/portainer:/data'
+      networks:
+         - agent_network
+      deploy:
+         mode: replicated
+         replicas: 1
+         placement:
+            constraints: [node.role == manager]
 
 networks:
-    agent_network:
-        driver: overlay
-        attachable: true
+   agent_network:
+      driver: overlay
+      attachable: true

--- a/stacks/portainer.yml
+++ b/stacks/portainer.yml
@@ -22,7 +22,7 @@ services:
          - '9000:9000'
          - '9443:9443'
       volumes:
-         - '../data/portainer:/data'
+         - 'data:/data'
       networks:
          - agent_network
       deploy:
@@ -35,3 +35,6 @@ networks:
    agent_network:
       driver: overlay
       attachable: true
+
+volumes:
+   data:


### PR DESCRIPTION
Implement a couple best practices:
- Use Docker volumes instead of bind mounts, which improves performance
- Do not use `latest` tag on images to ensure there are no surprise breakages