### PR TITLE
Improved stack upgrade support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ chmod +x init.sh && \
 sudo ./init.sh
 ```
 
-## Removing the GitHub Runner Service
+## FAQs
+
+### How do I *[insert cool thing here]* with the stacks?
+
+For more documentation about the stacks, please view the
+[stacks readme](./stacks/README.md).
+
+### How do I remove the GitHub Runner Service?
 
 If you've installed the GitHub Runner service and now you want to remove it, you can do so
 by following these steps:

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -1,13 +1,51 @@
 # Stacks
 
-This directory holds stacks that are ready for deployment to standard Docker hosts.
+This directory holds stacks that are ready for deployment to standard container hosts. The
+installers will properly install to either Docker or Podman hosts. When installing to a
+Podman host, a systemctl service will also be set up for the pod so that the containers
+will start on boot.
 
-## Nginx Proxy Manager
+## Inventory
+
+### Nginx Proxy Manager
 
 [Nginx Proxy Manager](https://nginxproxymanager.com) provides a reverse proxy to easily
 expose Docker services at a particular address, with an easy-to-use UI.
 
-## Portainer
+### Portainer
 
 [Portainer](https://www.portainer.io) is an easy-to-use administrative interface to your
 Docker environment, making it easy to monitor and configure your Docker services.
+
+## FAQs
+
+### How do I install the stacks without running the whole setup?
+
+You can run `./stacks/setup.sh` to just install the stacks, or run an individual stack's
+install script directly, such as `./stacks/nginx-proxy-manager-install.sh`.
+
+### How do I update the stacks with the latest version?
+
+First, ensure your `docker-host` instance is using the latest code by navigating to its
+directory and running `git pull`.
+
+For minor version bumps, you can stop the stack and reinstall it with the installer script
+and the `--upgrade` flag. This is not destructive; it will create containers using the
+same data/volumes you had already set up.
+
+#### Example: Stopping the stack
+
+```bash
+# On a Docker host, just use docker-compose:
+docker-compose -f stacks/nginx-proxy-manager.yml down
+# On a Podman host, you should use systemctl:
+systemctl stop nginxproxymanager
+```
+
+#### Example: Reinstalling the stack with the `--upgrade` flag
+
+```bash
+./stacks/nginx-proxy-manager-install.sh --upgrade
+```
+
+This will automatically pull the latest version of the images while reinstalling.

--- a/stacks/portainer-install.sh
+++ b/stacks/portainer-install.sh
@@ -8,8 +8,14 @@ echo "$(tput bold)
 $(tput sgr0)"
 sleep 2
 scr_dir="${0%/*}"
+yml_file="$scr_dir/portainer.yml"
+[[ $* == -u || $* == --upgrade ]] && upgrade_args=(--pull always)
 # Start the stack
-docker-compose -f "$scr_dir"/portainer.yml up -d
+if [[ $(docker --version) == podman* ]]; then
+   podman-compose --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
+else
+   docker-compose -f "$yml_file" up -d "${upgrade_args[@]}"
+fi
 # If we're using podman and `podman-install-service` is available, create the systemd service
 command -v podman-install-service &> /dev/null && podman-install-service portainer
 echo Done installing Portainer!

--- a/stacks/portainer.yml
+++ b/stacks/portainer.yml
@@ -7,7 +7,7 @@ networks:
 services:
 
    portainer:
-      image: docker.io/portainer/portainer-ce:2.21.0
+      image: docker.io/portainer/portainer-ce:2.21.4
       container_name: portainer
       privileged: true
       ports:


### PR DESCRIPTION
This improvement makes it easier to upgrade stacks provided by this project. The stack installers now have a `-u` or `--upgrade` flag so all you have to do is rerun the stack installer script to perform an upgrade. Also provided better stack documentation.

The `--upgrade` flag ultimately triggers a docker `--pull always` flag when running the containers, which asks docker to pull fresh images if there are newer ones. Note that the way docker vs. podman handle that argument is different 🙄 hence some if logic to handle the differences.

One could ask, "Why not just make the `--pull` argument part of default behavior so that the installer always pulls the latest version?" The goal here is to allow the admin to rerun the installer script and always know what will happen. An automatic upgrade could be unintended or happen at a bad time. By forcing an `--upgrade` flag, you will only be upgrading when you intend to.