### PR TITLE
Improve podman-install-service to connect to the service

### DIFF
--- a/rhel-9/bin/podman-install-service.sh
+++ b/rhel-9/bin/podman-install-service.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
+
+bold=$(tput bold)
+ul=$(tput smul)
+red=$(tput setaf 1)
+norm=$(tput sgr0)
+
+display_help() {
+   cat <<EOF
+Usage: $(basename "$0") <container or pod name> [OPTIONS]
+
+Creates a system service for a container or pod. The container or pod must be
+running. By default, it will restart the container or pod so that systemctl can
+track its status. If you don't want it to restart the service, you can use the
+option $bold--no-restart$norm, but then systemctl won't work until after an OS restart.
+
+Options:
+-h, --help         Show this help message and exit.
+-n, --no-restart   Don't restart the container when creating the service.
+EOF
+}
+
 svc_name="$1"
+[[ $* =~ -h || $* =~ --help ]] && display_help && exit
+[[ $* =~ -n || $* =~ --no-restart ]] && systemctl_opts=() || systemctl_opts=(--now)
 
 # Abort if service was not provided
-if [[ -z "$svc_name" ]]; then
-   echo "Usage: $0 <container or pod name>"
+if [[ -z "$svc_name" ]] || [[ $svc_name == -* ]]; then
+   echo -e "${red}You must provide a service name.$norm\n" >&2
+   display_help
    exit 1
 fi
 
@@ -14,7 +38,12 @@ if [[ $(docker --version) == podman* ]]; then
       echo "Setting up service as $(tput bold)$svc_name$(tput sgr0):"
       podman generate systemd --new --files --pod-prefix= --separator= --container-prefix= --name "$svc_name"
       systemctl daemon-reload
-      systemctl enable "$svc_name"
-      echo -e "\nExample usage: $(tput bold)$(tput smul)systemctl start $svc_name$(tput sgr0) to start the stack.\n"
+      systemctl enable "$svc_name" "${systemctl_opts[@]}"
+      if [[ ${systemctl_opts[*]} != *"--now"* ]]; then
+         echo "${red}Service was not restarted. You can't use systemctl until a system restart.$norm"
+      fi
+      echo -e "\nExample usage: ${bold}${ul}systemctl start $svc_name$norm to start the stack.\n"
    )
+else
+   echo "${red}You don't seem to be using podman. Aborting.$norm" >&2
 fi


### PR DESCRIPTION
The `podman-install-service` script would leave the `systemctl` service in a dead state where even though the container/pod was started, `systemctl` wouldn't know its status since it didn't start the container/pod. This weirdness obviously goes away the first time you reboot the system, since systemctl then starts up the service after restart.

Adding `--now` to a `systemctl enable` command will also issue a `systemctl start` command, which establishes systemctl's cognizance of the service.  Unfortunately, it restarts the service in the process, but it fixes the bug.

Some recommendations suggest to use `systemctl daemon-reload` to sync up with the service's status, but this suggestion does not work. It seems a `systemctl start` is the only way to fix the issue.

Usually a service restart when initially creating the service is considered satisfactory since it's probably been done before the service is in production. However, in case this is undesirable, we provide a `--no-restart` option to allow the user to avoid the service restart.

This fix isn't critical. It just helps avoid weirdness and unexpected behavior when it is first used.