### PR TITLE
Support for CI Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,44 @@ sudo ./init.sh
 For more documentation about the stacks, please view the
 [stacks readme](./stacks/README.md).
 
+### Using the `deploy` script
+
+For all environments, a `deploy` script is installed in the system that helps with
+deploying applications that use the docker-host environment. They provide a
+docker-compose stack and any additional required files (`.env` file, etc), and then
+deploy with this script.
+
+It takes these standard steps for deployment of UIC Pharmacy stacks:
+
+   - Login to your Docker repo
+   - Stop the application if it is currently running
+   - Create a pod *(if using podman)*
+   - Start up the stack using the stack path you provide
+   - Install the stack as a service *(if using podman)*
+
+Example:
+
+```bash
+deploy production.yml
+```
+
+This will automatically deploy the application and install it as a service named
+`prior-auth-drug-search-production`, if you are running a `podman` system.
+
+Note if you are using an environment file named something other than `.env`, you must
+pass it to the script as well:
+
+```bash
+deploy production.yml --env-file=production.env
+```
+
+The deploy script can handle upgrades as well. Just pass the `--upgrade` flag to ensure
+it handles pulling fresh container images:
+
+```bash
+deploy production.yml --upgrade
+```
+
 ### How do I remove the GitHub Runner Service?
 
 If you've installed the GitHub Runner service and now you want to remove it, you can do so
@@ -43,7 +81,7 @@ by following these steps:
 As `root`:
 
 ```sh
-cd /home/github/actions-runner
+cd /home/github/runner
 ./svc.sh stop
 ./svc.sh uninstall
 ```
@@ -51,6 +89,6 @@ cd /home/github/actions-runner
 Then, as the `github` user:
 
 ```sh
-cd actions-runner
+cd ~/runner
 ./config.sh remove --token your-token-supplied-by-github
 ```

--- a/centos-7/docker.sh
+++ b/centos-7/docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+scr_dir=$(realpath "${0%/*}")
+
 SCRIPT_TITLE="Install Docker"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
 echo -e "$(tput bold)\n#\n# $SCRIPT_TITLE \n#\n$(tput sgr0)"
@@ -20,6 +22,16 @@ elif [ -n "$(command -v firewall-cmd)" ]; then
    echo Opening up ports with firewall-cmd...
    firewall-cmd --add-port=2376/tcp --permanent
    firewall-cmd --reload
+fi
+
+# Add scripts to /usr/bin so it will be in the path
+if [ -d '/usr/bin' ]; then
+   bin_dir='/usr/bin'
+elif [ -d '/usr/local/bin' ]; then
+   bin_dir='/usr/local/bin'
+fi
+if [ -n "$bin_dir" ]; then
+   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
 fi
 
 # Start/Enable Docker

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,6 +1,8 @@
 aarch
+actionsdir
 adduser
 buildx
+chcon
 codeready
 containerd
 epel
@@ -13,9 +15,12 @@ jcurt
 lolhens
 makecache
 nodocker
+NOPASSWD
 realpath
 rmul
 rpms
+runnerdir
+runsvc
 runuser
 scriptnum
 setaf

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+scr_dir=$(realpath "${0%/*}")
+
 SCRIPT_TITLE="Install Docker Desktop"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
 echo -e "$(tput bold)\n#\n# $SCRIPT_TITLE \n#\n$(tput sgr0)"
@@ -13,3 +15,12 @@ open -a Docker
 echo -n 'Waiting for Docker Desktop to start up...'
 sleep 20
 until docker ps &> /dev/null; do echo -n '.'; sleep 5; done
+
+# Add scripts to /usr/local/bin so it will be in the path
+# (On macOS, we must use this one because /usr/bin is not permitted)
+if [ -d '/usr/local/bin' ]; then
+   bin_dir='/usr/local/bin'
+fi
+if [ -n "$bin_dir" ]; then
+   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
+fi

--- a/rhel-9/docker.sh
+++ b/rhel-9/docker.sh
@@ -17,8 +17,9 @@ elif [ -d '/usr/local/bin' ]; then
    bin_dir='/usr/local/bin'
 fi
 if [ -n "$bin_dir" ]; then
-   ln -s "$scr_dir/bin/docker-compose.sh" "$bin_dir/docker-compose"
-   ln -s "$scr_dir/bin/podman-install-service.sh" "$bin_dir/podman-install-service"
+   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
+   ln -f -s "$scr_dir/bin/docker-compose.sh" "$bin_dir/docker-compose"
+   ln -f -s "$scr_dir/bin/podman-install-service.sh" "$bin_dir/podman-install-service"
 fi
 
 # Silence Docker emulation messages

--- a/shared/bin/deploy.sh
+++ b/shared/bin/deploy.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+bold=$(tput bold)
+dim=$(tput dim)
+ul=$(tput smul)
+rmul=$(tput rmul)
+red=$(tput setaf 1)
+norm=$(tput sgr0)
+
+repo_default=ghcr.io/uicpharm
+repo=$repo_default
+upgrade=false
+verbose=false
+interactive=true
+env_file=
+
+display_help() {
+   cat <<EOF
+Usage: $(basename "$0") <stack path> [OPTIONS]
+
+Deploys an application stack with UIC Pharmacy standards:
+   - Login to your Docker repo
+   - Stop the application if it is currently running
+   - Create a pod $dim(if using podman)$norm
+   - Start up the stack using the stack path you point at
+   - Install the stack as a service $dim(if using podman)$norm
+
+Options:
+-h, --help              Show this help message and exit.
+-e, --env-file          Specify an alternate environment file.
+-n, --non-interactive   Do not prompt, run in non-interactive mode.
+-r, --repo              Specify the repo to login to. (Default: $ul$repo_default$rmul)
+-u, --upgrade           Upgrade by pulling the latest image.
+-v, --verbose           Provide more verbose output.
+EOF
+}
+
+# Positional parameter: Stack Path
+if [[ $1 == -* || -z $1 ]]; then
+   [[ $1 == -h || $1 == --help ]] || echo "${red}You must provide a stack path.$norm" >&2
+   display_help; exit 1;
+else
+   stack_path=$(realpath "$1")
+   shift
+fi
+
+# Collect optional arguments.
+# spellchecker: disable-next-line
+while getopts hnuve:r:-: OPT; do
+   # Ref: https://stackoverflow.com/a/28466267/519360
+   if [ "$OPT" = "-" ]; then
+      OPT="${OPTARG%%=*}"       # extract long option name
+      OPTARG="${OPTARG#"$OPT"}" # extract long option argument (may be empty)
+      OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+   fi
+   case "$OPT" in
+      h | help) display_help; exit 0 ;;
+      r | repo) repo=$OPTARG ;;
+      e | env-file) env_file=$(realpath "$OPTARG") ;;
+      n | non-interactive) interactive=false ;;
+      u | upgrade) upgrade=true ;;
+      v | verbose) verbose=true ;;
+      \?) echo "${red}Invalid option: -$OPT$norm" >&2 ;;
+      *) echo "${red}Some of these options are invalid:$norm $*" >&2; exit 2 ;;
+   esac
+done
+shift $((OPTIND - 1))
+
+# Validation
+[[ ! -e $stack_path ]] && echo "${red}The stack $ul$stack_path$rmul doesn't exist.$norm" >&2 && exit 2
+
+dir=${stack_path%/*}
+env_file=${env_file:-$dir/.env} # If no env file provided, use standard `.env` in stack directory
+pod_name=$(basename "$dir")-$(basename "$stack_path" .yml)
+
+$verbose && (
+   echo "$bold${ul}Settings$norm"
+   echo
+   echo "${bold}Stack Path:$norm $stack_path"
+   echo "${bold}Env File:$norm $env_file"
+   echo "${bold}Pod Name:$norm $pod_name"
+   echo "${bold}Repo:$norm $repo"
+   echo "${bold}Upgrade:$norm $upgrade"
+   echo
+)
+
+# Check if logged into ghcr.io/uicpharm
+$interactive && (
+   echo "Checking login to $repo..."
+   if ! docker login "$repo"; then
+      echo "Access to $repo is required. Aborting."
+      exit 1
+   fi
+)
+
+# Detect podman
+[[ $(docker --version) == podman* ]] && IS_PODMAN=true || IS_PODMAN=false
+
+# Detect podman-install-service
+which podman-install-service &> /dev/null && HAS_SERVICE_INSTALLER=true || HAS_SERVICE_INSTALLER=false
+
+# Stop the stack. Detect if its a service with systemctl or just a docker-compose stack.
+# By querying `is-active`, and then checking `docker-compose ps`, it will even catch the
+# scenario when the service is newly created but systemctl doesn't see it yet.
+if which systemctl &> /dev/null && ! systemctl status "$pod_name" 2>&1 | grep -q 'could not be found' && systemctl -q is-active "$pod_name"; then
+   systemctl stop "$pod_name"
+elif [[ $(docker-compose -f "$stack_path" --env-file "$env_file" ps -q 2>/dev/null | wc -w) -gt 0 ]]; then
+   docker-compose -f "$stack_path" down
+fi
+
+# Create pod
+$IS_PODMAN && ! podman pod exists "$pod_name" && podman pod create --name "$pod_name"
+
+# Prep docker-compose args
+podman_args=()
+docker_args=('-d')
+$IS_PODMAN && podman_args+=(--pod "$pod_name")
+
+# Upgrade stack if requested
+if $upgrade; then
+   $IS_PODMAN && podman_args+=(--pull always) || docker_args+=(--pull always)
+fi
+
+# Finalize args, start stack and install service
+[[ ${#podman_args[@]} -gt 0 ]] && podman_args=(--podman-run-args "${podman_args[*]}")
+(
+   cd "$dir" && \
+   docker-compose "${podman_args[@]}" -f "$stack_path" --env-file "$env_file" up "${docker_args[@]}" && \
+   $IS_PODMAN && $HAS_SERVICE_INSTALLER && podman-install-service "$pod_name" -n && \
+   echo "Installed service $pod_name!"
+)

--- a/shared/github-actions-runner.sh
+++ b/shared/github-actions-runner.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 
+norm=$(tput sgr0)
+ul=$(tput smul)
+rmul=$(tput rmul)
+bold=$(tput bold)
+red=$(tput setaf 1)
+
 SCRIPT_TITLE="Install GitHub Actions runner"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
-echo -e "$(tput bold)\n#\n# $SCRIPT_TITLE \n#\n$(tput sgr0)"
+echo -e "$bold\n#\n# $SCRIPT_TITLE \n#\n$norm"
 sleep 2
 
-# Setup a GitHub runner
-echo "$(tput bold)
-#
-# Install GitHub Actions runner...
-#
-$(tput sgr0)"
-sleep 2
-
-# Calculate installer filename based on system
+# Settings
+user=github
+runnerdir=runner
 org="uicpharm"
-ver="2.314.1"
+runner_version="2.321.0"
+
+# Detect OS/architecture
 [ "$(uname)" = 'Linux' ] && os='linux'
 [ "$(uname)" = 'Darwin' ] && os='osx'
 arch=$(uname -m | sed -e 's/aarch/arm/' -e 's/x86_/x/')
-installer_filename="actions-runner-$os-$arch-$ver.tar.gz"
 
 # If we can't find the right OS and arch, abort.
 if [ -z "$os" ] || [ -z "$arch" ]; then
@@ -27,24 +28,79 @@ if [ -z "$os" ] || [ -z "$arch" ]; then
    exit 1
 fi
 
-adduser github
-echo Set a password for the new \"github\" user
-passwd github
-usermod -aG docker github
+# Requires curl and jq utilities
+if [[ -z $(which curl) ]] || [[ -z $(which jq) ]]; then
+   echo "${red}${bold}This command requires ${ul}curl$rmul and ${ul}jq$rmul to work.$norm" >&2
+   exit 1
+fi
 
-# Actual installation steps of the github runner
-echo "Removing the existing 'actions-runner' directory, if it exists, to start fresh."
-runuser -l github -c "\
-   rm -Rf actions-runner && \
-   mkdir -p actions-runner && \
-   cd actions-runner && \
-   curl -O -L https://github.com/actions/runner/releases/download/v$ver/$installer_filename && \
+# Compare our version to latest version on GitHub. If they're different, see if
+# the user would like to use the latest version instead.
+latest_runner_version=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | sed 's/[a-z]//Ig')
+if [[ -n $latest_runner_version && $latest_runner_version != "$runner_version" ]]; then
+   echo "We've tested GitHub Actions Runner ${bold}${ul}v$runner_version$norm, but now ${bold}${ul}v$latest_runner_version$norm is available."
+   read -r -p "Do you want to use the newer version? [Y/n] " yorn
+   yorn=${yorn:-y} # Enter defaults to 'y'
+   yorn=$(echo "${yorn:0:1}" | tr '[:upper:]' '[:lower:]') # Take first character only, and convert to lowercase
+   [[ $yorn == y ]] && runner_version=$latest_runner_version
+fi
+
+# Calculate installer filename based on system
+installer_filename="actions-runner-$os-$arch-$runner_version.tar.gz"
+echo "Using GitHub Actions Runner installer $ul$installer_filename$norm."
+
+# Create the user and give permissions
+adduser $user
+echo "Set a password for the \"$user\" user"
+passwd $user
+usermod -aG docker $user 2>/dev/null
+
+# Add sudo rules for the new user. Instead of edit the main sudoers file, we create a
+# separate file in /etc/sudoers.d for just this user's rules.
+mkdir -p /etc/sudoers.d
+sudoers_file=/etc/sudoers.d/$user
+rm -f "$sudoers_file"
+for cmd in docker git deploy; do
+   bin=$(which "$cmd")
+   echo "$user ALL=(ALL) NOPASSWD: $bin" | tee -a "$sudoers_file" > /dev/null
+done
+chmod 0440 "$sudoers_file"
+# It's important to check the file so that sudo isn't messed up on the system
+if visudo -cf "$sudoers_file"; then
+   echo "Sudo rules added successfully for $user."
+else
+   echo "${bold}${red}Failed to add sudo rules. Please fix the issue.$norm" >&2
+   rm -f "$sudoers_file"
+fi
+
+# Actual installation steps of the runner (ran as the new user)
+actionsdir="$(eval echo "~$user")/$runnerdir"
+echo "Removing the existing '$actionsdir' directory, if it exists, to start fresh."
+runuser -l $user -c "\
+   rm -Rf $actionsdir && \
+   mkdir -p $actionsdir && \
+   cd $actionsdir && \
+   curl -O -L https://github.com/actions/runner/releases/download/v$runner_version/$installer_filename && \
    tar xzf ./$installer_filename \
 "
-sh -c /home/github/actions-runner/bin/installdependencies.sh
+sh -c "$actionsdir/bin/installdependencies.sh"
+
+# Configuration (also ran as the new user)
 echo "Please go to this link and find the token in the 'Configure' section:"
 echo "https://github.com/organizations/$org/settings/actions/runners/new?arch=$arch&os=$os"
 read -r -p "Type just the token: " tok
-runuser -l github -c "cd actions-runner && ./config.sh --url https://github.com/$org --token $tok"
-sh -c 'cd /home/github/actions-runner && ./svc.sh install && ./svc.sh start'
-echo Done installing GitHub Actions runner!
+h=${HOSTNAME,,}
+runuser -l $user -c "cd $actionsdir && ./config.sh --url https://github.com/$org --labels '${h%%.*},$h' --token $tok"
+
+# Now as the power user who is running the install script, set up the service
+(
+   cd "$actionsdir" && \
+   ./svc.sh install "$user" && \
+   # For SELinux systems, make sure runsvc.sh has the correct SELinux context
+   if which chcon &> /dev/null; then
+      echo "Setting the SELinux context for ${ul}runsvc.sh$rmul."
+      chcon -t bin_t -v "$actionsdir/runsvc.sh"
+   fi && \
+   ./svc.sh start && \
+   echo Done installing GitHub Actions runner!
+)


### PR DESCRIPTION
These enhancements pave the way for CI deployments via GitHub Actions by installing a self-hosted runner on our target servers. It makes the script for accomplishing that more concise by providing a `deploy` command that goes through the typical steps for deploying our apps.

### Enhancements to the GitHub Actions Runner installer

We already did the footwork of creating a script that helps automate the installation of a GitHub Actions runner. Now that we have real RedHat 9 servers, we were able to identify some necessary changes. For instance:

- Since most projects will be checked out with `root` and run in privileged podman containers, the `github` user that runs the runner service would need to have proper permissions. We don't want to assign more than it needs, so we gave it sudo permissions *only* for the deploy, docker, and git commands. We accomplish this by writing a separate file just for this purpose in `/etc/sudoers.d/`. 
- We ensure the runner service is set up to run as the `github` user.
- If the `chcon` command is present, we know we're dealing with an SELinux system. We assign proper contexts so the service will work in SELinux.
- We automatically assign the runner a label of the hostname of the server.
- We set it to the latest version available for the runner installer.

### The deploy command

The `deploy` command is made to properly run in a Docker or Podman environment. So, its installation was added as part of the "Docker/Podman" installation step for every environment (currently CentOS, RHEL, and macOS).  The command has a nice help screen (`deploy --help`), but here is a brief description:

It will go through these steps:
   - Login to your Docker repo
   - Stop the application if it is currently running
   - Create a pod *(if using podman)*
   - Start up the stack using the stack path you point at
   - Install the stack as a service *(if using podman)*

Some additional notes:
- If your deployment uses an environment variable name other then `.env`, you can use `--env-file` to specify the environment file.
- The `--non-interactive` flag skips the docker repository login step, which prompts the user for credentials. This can be used in CI scripts when we can't respond to user prompts.
- It provides easy ability to redeploy/upgrade, because it stops and starts the stack, and with the `--upgrade` flag, will pull for fresh images even if it already has them, which benefits configurations that do something like `mariadb:10` to always point to the latest of that version.
- It's intelligent enough to be savvy of the situation where `systemctl` is not cognizant of newly-created services, and will gracefully handle the situation regardless of a docker, podman, or systemctl situation.

### Bringing it all together

The deployment command makes it so that deploying or redeploying a UIC Pharmacy app can be done from one command. This means that deployment CI workflows can be created that are very concise.  A good first use case to demonstrate this is [prior-auth-drug-search - deploy.yml](https://github.com/uicpharm/prior-auth-drug-search/blob/998c36154d474595da57c0da4e92254f0a335c48/.github/workflows/deploy.yml). 
