### PR TITLE
Security for secrets directory

### DIFF
--- a/custom-words.txt
+++ b/custom-words.txt
@@ -3,6 +3,7 @@ actionsdir
 adduser
 buildx
 chcon
+chgrp
 codeready
 containerd
 epel
@@ -14,6 +15,7 @@ installdependencies
 jcurt
 lolhens
 makecache
+mktemp
 nodocker
 NOPASSWD
 realpath

--- a/stacks/setup.sh
+++ b/stacks/setup.sh
@@ -2,6 +2,44 @@
 
 scr_dir="${0%/*}"
 
+# Collect user groups. We do this in the background right away since a server connected to AD may take
+# several seconds to respond with the group list.
+real_user=${SUDO_USER:-$(whoami)}
+groups_file=$(mktemp)
+(id "$real_user" | cut -d'=' -f4 | tr ',' '\n' > "$groups_file") &
+groups_pid="$!"
+
+# Create secrets directory
+sec_dir=$(realpath "$scr_dir/..")/secrets
+mkdir -p "$sec_dir"
+
+# Set strict permissions for the secrets
+echo "It is highly recommended that you restrict permissions of the $(tput smul)$(basename "$sec_dir")$(tput rmul) directory."
+echo "I can set the group to something your $real_user user also has access to."
+read -r -p "Do you want to do this? [Y/n] " yorn
+if [[ ${yorn:-y} =~ [Yy] ]]; then
+   echo -n "Great! Finding your user groups."
+   while ps "$groups_pid" > /dev/null; do echo -n '.'; sleep 1; done
+   echo -e '\n'
+   while IFS=$'\n' read -r line; do
+      group_array+=("$line")
+   done <<< "$(<"$groups_file")"
+   PS3="Either enter a number or manually type a group name: "
+   select group in "${group_array[@]}"; do
+      # Accept either the selected group or the manually-entered group
+      group=${group:-$REPLY}
+      # Don't accept a blank entry
+      [[ -n $group ]] && break
+   done
+   echo "Setting the group of the $(tput smul)$(basename "$sec_dir")$(tput rmul) directory to $(tput smul)$group$(tput rmul)."
+   # Groups will look like "123(group_name)", so we get just the number by looking to the left of '('.
+   # This will also work with manually entered groups like "group_name" or "123".
+   group=$(echo "$group" | cut -d'(' -f1)
+   chgrp -R "$group" "$sec_dir"
+   chmod -R 770 "$sec_dir"
+fi
+
+# Install individual stacks
 for stackinstaller in "$scr_dir"/*-install.sh; do
    stackname="$(basename "$stackinstaller" | sed -e "s/-install.sh//")"
    echo -n "Do you want to install $stackname? [Y/n]: "


### PR DESCRIPTION
Currently, only the Nginx Proxy Manager stack uses the `secrets` directory, but it's intended to be available for any `docker-host` stack that will need secrets.  So, we add the installation of the `secrets` directory to the main `setup.sh` installer for stacks.

Additionally, though, it's important to incorporate security into the creation of this directory, so that the admin is not expected to have to do it after the fact to be secure.  At the very least, the directory should have all perms removed from "others".

To ensure the directory can be readable by the user doing the install, who is probably the admin, we also give the option to set the "group" of the directory to a group that the user is a member of. This is just a nicety but really makes things more convenient.

The whole security setting step can be skipped by the user if desired.

### Notes

On systems integrated with AD, retrieval of user groups may be slow, taking many seconds. So, we retrieve the user's groups in the background right away, so that by the time we want to list the user's groups, the wait will be shorter or even no wait at all.

By using the [id](https://man7.org/linux/man-pages/man1/id.1.html) command, we get group IDs *and* names, so it is most accurate (by using the ID) and user-friendly (by showing the name).

