### PR TITLE
Publish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,52 @@ it handles pulling fresh container images:
 deploy production.yml --upgrade
 ```
 
+### Using the `publish` script
+
+For all environments, the `publish` script helps with building and publishing container
+images from your workstation to our container registry. It builds the image using the UIC
+Pharmacy standards, such as:
+
+   - Uses semantic versioning based on the `version` defined in `package.json`, including
+     intelligent re-tagging of major versions. For instance, version `1.2.3` will also
+     tag versions `1` and `1.2`, however a prerelease like `1.2.3-beta.1` will not.
+   - Automatically adds the image to the correct repo as long as its `homepage` is set in
+     `package.json`.
+   - Creates a multi-arch manifest, so images are built for Intel and Apple Silicon
+     architectures.
+   - Automatically finds the context and `package.json` by assuming they're in the same
+     directory as the Dockerfile.
+
+Since podman and buildah do not support non-native architecture builds (i.e. building for
+arm64 in an amd64 environment), this script will force building only for your native
+architecture when it runs in a podman environment.
+
+You can build and publish the image for a project with a single Dockerfile by just
+referencing the Dockerfile in the command:
+
+```bash
+# For project 'foo', creates image 'ghcr.io/uicpharm/foo':
+publish path/to/Dockerfile
+```
+
+If you have a project with multiple Docker files, build them one at a time, assigning an
+additional name that can be appended to the image.
+
+```bash
+# For project 'foo', creates image 'ghcr.io/uicpharm/foo/bar':
+publish path/to/Dockerfile.bar --name=bar
+```
+
+If you want to make sure it's working without actually publishing, here are some things
+you could do to check it:
+
+`--dry-run` will show you the commands that will run, without actually running them.
+
+`--no-push` will build the images but not push them to the registry.
+
+`--verbose` will show you a summary of all the settings that will be used for the build
+and publishing process.
+
 ### How do I remove the GitHub Runner Service?
 
 If you've installed the GitHub Runner service and now you want to remove it, you can do so

--- a/centos-7/docker.sh
+++ b/centos-7/docker.sh
@@ -31,7 +31,9 @@ elif [ -d '/usr/local/bin' ]; then
    bin_dir='/usr/local/bin'
 fi
 if [ -n "$bin_dir" ]; then
-   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
+   for scr_name in "$scr_dir"/../shared/bin/*.sh; do
+      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+   done
 fi
 
 # Start/Enable Docker

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -1,6 +1,7 @@
 aarch
 actionsdir
 adduser
+buildah
 buildx
 chcon
 chgrp
@@ -18,6 +19,7 @@ makecache
 mktemp
 nodocker
 NOPASSWD
+opencontainers
 realpath
 rmul
 rpms

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -22,5 +22,7 @@ if [ -d '/usr/local/bin' ]; then
    bin_dir='/usr/local/bin'
 fi
 if [ -n "$bin_dir" ]; then
-   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
+   for scr_name in "$scr_dir"/../shared/bin/*.sh; do
+      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+   done
 fi

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -30,7 +30,8 @@ if [ -d '/usr/local/bin' ]; then
    bin_dir='/usr/local/bin'
 fi
 if [ -n "$bin_dir" ]; then
+   echo "Installing scripts to $bin_dir may require a password."
    for scr_name in "$scr_dir"/../shared/bin/*.sh; do
-      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+      sudo ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
    done
 fi

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -8,13 +8,21 @@ echo -e "$(tput bold)\n#\n# $SCRIPT_TITLE \n#\n$(tput sgr0)"
 sleep 2
 
 eval "$(/opt/homebrew/bin/brew shellenv)"
-brew install --cask docker
-brew install docker-compose
+if which docker &>/dev/null; then
+   echo 'Already installed: Docker'
+else
+   brew install --cask docker
+fi
+if which docker-compose &>/dev/null; then
+   echo 'Already installed: docker-compose'
+else
+   brew install docker-compose
+fi
 sleep 3
 open -a Docker
 echo -n 'Waiting for Docker Desktop to start up...'
-sleep 20
 until docker ps &> /dev/null; do echo -n '.'; sleep 5; done
+echo
 
 # Add scripts to /usr/local/bin so it will be in the path
 # (On macOS, we must use this one because /usr/bin is not permitted)

--- a/rhel-9/docker.sh
+++ b/rhel-9/docker.sh
@@ -17,9 +17,12 @@ elif [ -d '/usr/local/bin' ]; then
    bin_dir='/usr/local/bin'
 fi
 if [ -n "$bin_dir" ]; then
-   ln -f -s "$(realpath "$scr_dir/../shared/bin/deploy.sh")" "$bin_dir/deploy"
-   ln -f -s "$scr_dir/bin/docker-compose.sh" "$bin_dir/docker-compose"
-   ln -f -s "$scr_dir/bin/podman-install-service.sh" "$bin_dir/podman-install-service"
+   for scr_name in "$scr_dir"/../shared/bin/*.sh; do
+      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+   done
+   for scr_name in "$scr_dir"/bin/*.sh; do
+      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+   done
 fi
 
 # Silence Docker emulation messages

--- a/rhel-9/docker.sh
+++ b/rhel-9/docker.sh
@@ -30,8 +30,9 @@ touch /etc/containers/nodocker
 
 # Network fix to allow multiple networks associated to a container
 # Ref: https://virtualzone.de/posts/podman-multiple-networks/
-sysctl -w net.ipv4.conf.all.rp_filter=2
-echo "net.ipv4.conf.all.rp_filter=2" >> /etc/sysctl.conf
+setting='net.ipv4.conf.all.rp_filter=2'
+sysctl -w "$setting"
+grep -q "$setting" /etc/sysctl.conf || echo "$setting" >> /etc/sysctl.conf
 
 # SELinux setting for systemd service creation
 setsebool -P container_manage_cgroup on

--- a/shared/bin/publish.sh
+++ b/shared/bin/publish.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+bold=$(tput bold)
+ul=$(tput smul)
+rmul=$(tput rmul)
+red=$(tput setaf 1)
+yellow=$(tput setaf 3)
+norm=$(tput sgr0)
+
+arches_default=linux/aarch64,linux/x86_64
+org_default=uicpharm
+reg_default=ghcr.io
+
+arches=$arches_default
+org=$org_default
+reg=$reg_default
+name_append=
+dry_run=false
+exact=false
+push=true
+verbose=false
+
+err() { echo "$red$1$norm" >&2; }
+warn() { echo "$yellow$1$norm" >&2; }
+exec_cmd() { if $dry_run; then echo "${yellow}Command:${norm} $1" | tr -s ' '; else eval "$1"; fi }
+
+display_help() {
+   cat <<EOF
+Usage: $(basename "$0") <Dockerfile> [context] [OPTIONS]
+
+Builds and publishes a container image with UIC Pharmacy standards:
+   - Semantic versioning based on ${ul}version$norm in package.json
+   - Automatically assign to a repo based on ${ul}homepage$norm in package.json
+   - Create a multi-arch manifest
+   - Assumes context same directory as Dockerfile. You can specify if needed.
+
+This supports multiple images for a single repo. You can use $bold--name$norm to specify
+the additional name. So, if your repo name is ${bold}foo$norm and $bold--name=bar$norm, then the full
+name would be ${bold}foo/bar$norm.
+
+Options:
+-h, --help        Show this help message and exit.
+-a, --arch        Architectures to build for. (Default: $ul$arches_default$rmul)
+-e, --exact       Only tag the exact version from the package file.
+-n, --name        Additional name to append to the image name.
+-o, --org         Organization to push to. (Default: $ul$org_default$rmul)
+-r, --registry    Registry to push to. (Default: $ul$reg_default$rmul)
+    --dry-run     Show what would've happened without executing.
+    --no-push     Create the images, but do not push to registry.
+-v, --verbose     Provide more verbose output.
+EOF
+}
+
+# Positional parameter: Docker file
+if [[ $1 == -* || -z $1 ]]; then
+   [[ $1 == -h || $1 == --help ]] || err "You must provide a Docker file."
+   display_help; exit 1;
+else
+   dockerfile=$(realpath "$1")
+   shift
+fi
+
+# Positional parameter: Context
+if [[ $1 == -* || -z $1 ]]; then
+   # If not provided, we assume same dir as Docker file
+   context=$(dirname "$dockerfile")
+else
+   context=$(realpath "$1")
+   shift
+fi
+
+# Collect optional arguments.
+# spellchecker: disable-next-line
+while getopts heva:n:o:r:-: OPT; do
+   # Ref: https://stackoverflow.com/a/28466267/519360
+   if [ "$OPT" = "-" ]; then
+      OPT="${OPTARG%%=*}"       # extract long option name
+      OPTARG="${OPTARG#"$OPT"}" # extract long option argument (may be empty)
+      OPTARG="${OPTARG#=}"      # if long option argument, remove assigning `=`
+   fi
+   case "$OPT" in
+      h | help) display_help; exit 0 ;;
+      a | arch) arches=$OPTARG ;;
+      e | exact) exact=true ;;
+      dry-run) dry_run=true ;;
+      no-push) push=false ;;
+      n | name) name_append=${OPTARG// /} ;;
+      o | org) org=$OPTARG ;;
+      r | registry) reg=$OPTARG ;;
+      v | verbose) verbose=true ;;
+      \?) err "Invalid option: -$OPT" ;;
+      *) err "Some of these options are invalid: $*"; exit 2 ;;
+   esac
+done
+shift $((OPTIND - 1))
+
+# Check dependencies, and abort if any are missing
+for c in tput realpath dirname basename docker jq; do
+   if ! which "$c" &>/dev/null; then
+      err "The $ul$c$rmul command is required by this script. Aborting."
+      exit 1
+   fi
+done
+
+# Detect podman
+[[ $(docker --version) == podman* ]] && is_podman=true || is_podman=false
+
+# Check arch... when running as podman, only support native arch.
+# Get arch info from docker/podman itself. Sadly, they report that info differently.
+docker_info=$(docker info -f json)
+native_arch=$(jq -r '.OSType' <<< "$docker_info")/$(jq -r '.Architecture' <<< "$docker_info")
+$is_podman && native_arch=$(jq -r '.host.os' <<< "$docker_info")/$(jq -r '.host.arch' <<< "$docker_info")
+if $is_podman && [[ $arches != "$native_arch" ]]; then
+   arches=$native_arch
+   warn "When running podman, you can only run your native architecture. Changing target arch to $ul$arches$rmul."
+fi
+
+# Repo package info
+name=$(jq -r '.name' "$context/package.json" | tr -d ' ')
+ver=$(jq -r '.version' "$context/package.json" | tr -d ' ')
+homepage=$(jq -r '.homepage' "$context/package.json" | tr -d ' ')
+
+# Validation of name/version as required values
+[[ $name == null ]] && name=
+[[ -z $name ]] && err "No ${ul}name$rmul provided in package.json." && exit 1
+[[ $ver == null ]] && ver=
+[[ -z $ver ]] && err "No ${ul}version$rmul provided in package.json." && exit 1
+img=$reg/$org/$name${name_append:+/$name_append}
+
+# We want homepage without any anchor or query params
+homepage=${homepage%#*}
+homepage=${homepage%\?*}
+# Warn if homepage is not provided
+[[ $homepage == null ]] && homepage=
+[[ -z $homepage ]] && warn "No ${ul}homepage$rmul provided in package.json. The image will be pushed, but will not be assigned to a repository."
+
+# Make sure container builder exists (not needed for podman)
+if ! $is_podman; then
+   builder="$org-builder"
+   builder_param="--builder $builder"
+   if ! docker builder inspect "$builder" &>/dev/null; then
+      $verbose && echo -n 'Creating custom builder: '
+      exec_cmd "docker builder create --name $builder"
+   fi
+fi
+
+# Parse the version into major, minor, and patch components
+maj=$(echo "$ver" | awk -F. '{print $1}')
+min=$(echo "$ver" | awk -F. '{print $2}')
+pat=$(echo "$ver" | awk -F. '{print $3}')
+
+# Generate different tags
+tag_maj=$img:$maj
+tag_min=$img:$maj.$min
+tag_pat=$img:$maj.$min.$pat
+tag_full=$img:$ver
+latest=$img:latest
+
+# Use all variations for normal versions, but not for prereleases
+if ! $exact && [[ $tag_full == "$tag_pat" ]]; then
+   tags=("$tag_maj" "$tag_min" "$tag_pat" "$latest")
+else
+   tags=("$tag_full")
+fi
+
+# Output the variables for verification
+if $verbose; then
+   echo
+   echo "${bold}${ul}Building $img$norm"
+   echo
+   [[ -n $builder ]] && echo "${bold}Builder:$norm $builder"
+   echo "${bold}Dockerfile:$norm $dockerfile"
+   echo "${bold}Context:$norm $context"
+   [[ -n $homepage ]] && echo "${bold}Parent project:$norm $homepage"
+   echo "${bold}Package version:$norm $ver"
+   echo  "${bold}Tags:$norm"
+   for tag in "${tags[@]}"; do echo "  - $tag"; done
+   echo "${bold}Platforms:$norm"
+   for a in ${arches//,/ }; do echo "  - $a"; done
+   echo
+fi
+
+#
+# Docker builds the image and only keeps it in the builder cache unless you push it.
+# Podman tags the images in your local images, but doesn't support a `--push` flag. So,
+# if the user is pushing the images, we use `--push` for Docker, but for podman we use
+# additional `docker push <tag>` calls.
+#
+
+# Build images and push them to the registry
+$push && ! $is_podman && push_param=--push
+exec_cmd "docker build \
+   -f $dockerfile \
+   --platform $arches \
+   $(for tag in "${tags[@]}"; do echo -n "-t $tag "; done) \
+   ${homepage:+--annotation "org.opencontainers.image.source=$homepage"} \
+   $builder_param \
+   $push_param \
+   $context"
+
+# In podman, we have to push the tags after building
+$is_podman && $push && for tag in "${tags[@]}"; do
+   exec_cmd "docker push $tag"
+done
+
+# Stop builder when done (not needed for podman)
+$is_podman || exec_cmd "docker builder stop $builder"


### PR DESCRIPTION
The purpose of this PR is to introduce a `publish` script that simplifies the process of building and publish container images to our registry at `ghcr.io/uicpharm`, although it's extensible to allow other registry/org values.

This script will automatically handle the creation of a custom builder using the `docker-container` driver as outlined in Docker's [Multi-platform build documentation](https://docs.docker.com/build/building/multi-platform/). It also will handle the different syntax/logistics for building in Docker versus Podman, although in Podman it forces you to only build for your native architecture. 

This PR also improves the installers so that they will install *all* `*.sh` helper scripts that are in the `bin` directories, for either the specific OS or the one in the `shared` directory. This will make it simpler to add a script to the bunch in the future, without having to edit the installers every time. Furthermore, the docker portion of the installer has been improved so it can be ran over again, which makes it easy to install the Docker-related helper scripts by just re-running the `docker.sh` installer.

### Why??

Typically, building and publishing of images should happen in a GitHub Actions workflow when a version is tagged. However, if there is any reason why this is impossible/undesirable, this script could be used on a workstation that is capable of building and publishing the images.

For instance, the [dcfs-summary](https://github.com/uicpharm/dcfs-summary) project cannot currently build the `linux/arm64` version of the image, because the standard `linux/amd64` arch used by GHA throws errors when trying to build the `linux/arm64` image in its emulation layer (https://github.com/uicpharm/dcfs-summary/issues/2). So, its workflow was [adjusted to only publish linux/amd64 images](https://github.com/uicpharm/dcfs-summary/commit/425f309f19df16f5aa7d785eb1b27d12e69b9607). That way, at least the standard arch used by the server is built. If a `linux/arm64` image is desired, a Mac user can rebuild the multi-arch image, since the Mac arch can successful build both, and then publish it to the repository.

### How to test

After checking out this branch in your `docker-host` directory, execute the `docker.sh` script that is in the directory that matches your OS. Re-running `docker.sh` will install all scripts, including the new `publish` script.

View the [Using the publish script](https://github.com/uicpharm/docker-host/blob/6e81654307036e04c55fa2076b73c3322bd0a52f/README.md#using-the-publish-script) docs in the readme. This will give examples of how to run it.
