### PR TITLE
Compose fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ For more documentation about the stacks, please view the
 ### Using the `deploy` script
 
 For all environments, a `deploy` script is installed in the system that helps with
-deploying applications that use the docker-host environment. They provide a
-docker-compose stack and any additional required files (`.env` file, etc), and then
-deploy with this script.
+deploying applications that use the docker-host environment. They provide a compose stack
+and any additional required files (`.env` file, etc), and then deploy with this script.
 
 It takes these standard steps for deployment of UIC Pharmacy stacks:
 

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -7,6 +7,7 @@ chcon
 chgrp
 codeready
 containerd
+dotenv
 epel
 gluster
 glusterd

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -13,11 +13,6 @@ if which docker &>/dev/null; then
 else
    brew install --cask docker
 fi
-if which docker-compose &>/dev/null; then
-   echo 'Already installed: docker-compose'
-else
-   brew install docker-compose
-fi
 sleep 3
 open -a Docker
 echo -n 'Waiting for Docker Desktop to start up...'

--- a/rhel-9/docker.sh
+++ b/rhel-9/docker.sh
@@ -8,7 +8,7 @@ echo -e "$(tput bold)\n#\n# $SCRIPT_TITLE \n#\n$(tput sgr0)"
 sleep 2
 
 # Standard Install
-dnf install -y container-tools podman-compose
+dnf install -y python-dotenv container-tools podman-compose
 
 # Add scripts to /usr/bin so it will be in the path
 if [ -d '/usr/bin' ]; then

--- a/shared/bin/deploy.sh
+++ b/shared/bin/deploy.sh
@@ -123,15 +123,14 @@ $IS_PODMAN && ! podman pod exists "$pod_name" && podman pod create --name "$pod_
 # Prep compose args
 podman_args=()
 docker_args=('-d')
-$IS_PODMAN && podman_args+=(--pod "$pod_name")
+$IS_PODMAN && podman_args+=(--in-pod "$pod_name")
 
 # Upgrade stack if requested
 if $upgrade; then
-   $IS_PODMAN && podman_args+=(--pull always) || docker_args+=(--pull always)
+   $IS_PODMAN && podman_args+=(--podman-run-args '--pull always') || docker_args+=(--pull always)
 fi
 
-# Finalize args, start stack and install service
-[[ ${#podman_args[@]} -gt 0 ]] && podman_args=(--podman-run-args "${podman_args[*]}")
+# Start stack and install service
 (
    cd "$dir" && \
    compose "${podman_args[@]}" -f "$stack_path" --env-file "$env_file" up "${docker_args[@]}" && \

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -36,8 +36,8 @@ same data/volumes you had already set up.
 #### Example: Stopping the stack
 
 ```bash
-# On a Docker host, just use docker-compose:
-docker-compose -f stacks/nginx-proxy-manager.yml down
+# On a Docker host, just use docker compose:
+docker compose -f stacks/nginx-proxy-manager.yml down
 # On a Podman host, you should use systemctl:
 systemctl stop nginxproxymanager
 ```

--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -21,7 +21,7 @@ mkdir -p "$sec_dir"
 svc_name="nginxproxymanager"
 if [[ $(docker --version) == podman* ]]; then
    podman pod create --name "$svc_name"
-   podman-compose --podman-run-args "--pod $svc_name ${upgrade_args[*]}" -f "$yml_file" up -d
+   podman-compose --in-pod "$svc_name" --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
 else
    docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
 fi

--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -23,7 +23,7 @@ if [[ $(docker --version) == podman* ]]; then
    podman pod create --name "$svc_name"
    podman-compose --podman-run-args "--pod $svc_name ${upgrade_args[*]}" -f "$yml_file" up -d
 else
-   docker-compose -f "$yml_file" up -d "${upgrade_args[@]}"
+   docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
 fi
 # If we're using podman and `podman-install-service` is available, create the systemd service
 command -v podman-install-service &> /dev/null && podman-install-service "$svc_name"

--- a/stacks/portainer-install.sh
+++ b/stacks/portainer-install.sh
@@ -11,11 +11,13 @@ scr_dir="${0%/*}"
 yml_file="$scr_dir/portainer.yml"
 [[ $* == -u || $* == --upgrade ]] && upgrade_args=(--pull always)
 # Start the stack
+svc_name="portainer"
 if [[ $(docker --version) == podman* ]]; then
-   podman-compose --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
+   podman pod create --name "$svc_name"
+   podman-compose --in-pod "$svc_name" --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
 else
    docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
 fi
 # If we're using podman and `podman-install-service` is available, create the systemd service
-command -v podman-install-service &> /dev/null && podman-install-service portainer
+command -v podman-install-service &> /dev/null && podman-install-service "$svc_name"
 echo Done installing Portainer!

--- a/stacks/portainer-install.sh
+++ b/stacks/portainer-install.sh
@@ -14,7 +14,7 @@ yml_file="$scr_dir/portainer.yml"
 if [[ $(docker --version) == podman* ]]; then
    podman-compose --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
 else
-   docker-compose -f "$yml_file" up -d "${upgrade_args[@]}"
+   docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
 fi
 # If we're using podman and `podman-install-service` is available, create the systemd service
 command -v podman-install-service &> /dev/null && podman-install-service portainer


### PR DESCRIPTION
This work addresses a couple issues with our project in connection with compose files, namely:
- It has expected usage of `docker-compose`, instead of using the newer `docker compose` plugin for `docker`.
- Newer versions of `podman-compose` necessitate some changes when running in podman environments.

So, to address these issues, we:
- Change all references to `docker-compose` to just use `docker compose`, and remove `docker-compose` from the installation scripts for macOS. 
- Update all code referencing podman and podman-compose to use `--in-pod`, and ensure dependencies for podman-compose are installed.