### PR TITLE
Ephemeral installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,10 @@ support by virtue of support for Ubuntu. Actual Docker installation is handled b
 installation script, but you can use the stacks installer directly on any *nix machine by
 running [stacks/setup.sh](./stacks/setup.sh).
 
-Login as root and execute:
+To begin a standard installation:
 
-```sh
-source <(curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/main/init.sh)
-```
-
-The script will download the project and walk you through executing the scripts.
-
-If you cannot login as root and can only sudo, then download it to your home directory and
-execute it from there:
-
-```sh
-curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/main/init.sh > init.sh && \
-chmod +x init.sh && \
-sudo ./init.sh
+```bash
+bash <(curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/main/init.sh)
 ```
 
 ## FAQs

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -23,6 +23,7 @@ nodocker
 NOPASSWD
 opencontainers
 realpath
+Retzky
 rmul
 rpms
 runnerdir

--- a/macos/docker.sh
+++ b/macos/docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 scr_dir=$(realpath "${0%/*}")
+[[ -z $DEV ]] && DEV=false
 
 SCRIPT_TITLE="Install Docker Desktop"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
@@ -21,12 +22,16 @@ echo
 
 # Add scripts to /usr/local/bin so it will be in the path
 # (On macOS, we must use this one because /usr/bin is not permitted)
-if [ -d '/usr/local/bin' ]; then
-   bin_dir='/usr/local/bin'
-fi
-if [ -n "$bin_dir" ]; then
-   echo "Installing scripts to $bin_dir may require a password."
+bin_dir=/usr/local/bin
+sudo install -d $bin_dir
+if [[ -d $bin_dir ]]; then
+   echo "Installing scripts to $(tput smul)$bin_dir$(tput rmul) (may require a password):"
    for scr_name in "$scr_dir"/../shared/bin/*.sh; do
-      sudo ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+      cmd=(sudo install -b -v) && $DEV && cmd=(sudo ln -f -v -s)
+      cmd+=("$(realpath "$scr_name")")
+      cmd+=("$bin_dir/$(basename "$scr_name" .sh)")
+      "${cmd[@]}"
    done
+else
+   echo "$(tput setaf 1)Cannot install scripts to $(tput smul)$bin_dir$(tput rmul) because it wasn't found.$(tput sgr0)" >&2
 fi

--- a/rhel-9/bin/docker-compose.sh
+++ b/rhel-9/bin/docker-compose.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/sh
-exec /usr/bin/podman-compose "$@"

--- a/rhel-9/bin/podman-install-service.sh
+++ b/rhel-9/bin/podman-install-service.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
+version=1.0.0
 bold=$(tput bold)
 ul=$(tput smul)
 red=$(tput setaf 1)
 yellow=$(tput setaf 3)
 norm=$(tput sgr0)
 
+display_version() {
+   hash=$(cat "$0" | sha256sum | cut -c1-8)
+   echo "$(basename "$0") version $version build $hash"
+}
+
 display_help() {
    cat <<EOF
+$bold$(display_version)$norm
+${red}UIC Retzky College of Pharmacy$norm
+
 Usage: $(basename "$0") <container or pod name> [OPTIONS]
 
 Creates a system service for a container or pod. The container or pod must be
@@ -18,17 +27,18 @@ option $bold--no-restart$norm, but then systemctl won't work until after an OS r
 Options:
 -h, --help         Show this help message and exit.
 -n, --no-restart   Don't restart the container when creating the service.
+-V, --version      Print version and exit.
 EOF
 }
 
 svc_name="$1"
-[[ $* =~ -h || $* =~ --help ]] && display_help && exit
+[[ $* =~ -h || $* =~ --help ]] && display_help && exit 1
+[[ $* =~ -V || $* =~ --version ]] && display_version && exit 1
 [[ $* =~ -n || $* =~ --no-restart ]] && systemctl_opts=() || systemctl_opts=(--now)
 
 # Abort if service was not provided
 if [[ -z "$svc_name" ]] || [[ $svc_name == -* ]]; then
-   echo -e "${red}You must provide a service name.$norm\n" >&2
-   display_help
+   echo -e "${red}You must provide a service name.$norm" >&2
    exit 1
 fi
 

--- a/rhel-9/bin/podman-install-service.sh
+++ b/rhel-9/bin/podman-install-service.sh
@@ -42,8 +42,8 @@ if [[ -z "$svc_name" ]] || [[ $svc_name == -* ]]; then
    exit 1
 fi
 
-# Only run if "docker" is answering as podman
-if [[ $(docker --version) == podman* ]]; then
+# Only run if we are using podman
+if [[ $(podman --version 2>/dev/null) == podman* ]]; then
    (
       cd /etc/systemd/system || exit 1
       echo "Setting up service as $(tput bold)$svc_name$(tput sgr0):"

--- a/rhel-9/docker.sh
+++ b/rhel-9/docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 scr_dir=$(realpath "${0%/*}")
+[[ -z $DEV ]] && DEV=false
 
 SCRIPT_TITLE="Install Docker/Podman"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
@@ -11,18 +12,21 @@ sleep 2
 dnf install -y python-dotenv container-tools podman-compose
 
 # Add scripts to /usr/bin so it will be in the path
-if [ -d '/usr/bin' ]; then
-   bin_dir='/usr/bin'
-elif [ -d '/usr/local/bin' ]; then
-   bin_dir='/usr/local/bin'
+if [[ -d /usr/bin ]]; then
+   bin_dir=/usr/bin
+elif [[ -d /usr/local/bin ]]; then
+   bin_dir=/usr/local/bin
 fi
-if [ -n "$bin_dir" ]; then
-   for scr_name in "$scr_dir"/../shared/bin/*.sh; do
-      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+if [[ -n $bin_dir ]]; then
+   echo "Installing scripts to $(tput smul)$bin_dir$(tput rmul) (may require a password):"
+   for scr_name in "$scr_dir"/../shared/bin/*.sh "$scr_dir"/bin/*.sh; do
+      cmd=(install -b -v) && $DEV && cmd=(ln -f -v -s)
+      cmd+=("$(realpath "$scr_name")")
+      cmd+=("$bin_dir/$(basename "$scr_name" .sh)")
+      "${cmd[@]}"
    done
-   for scr_name in "$scr_dir"/bin/*.sh; do
-      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
-   done
+else
+   echo "$(tput setaf 1)Cannot install scripts to $(tput smul)$bin_dir$(tput rmul) because it wasn't found.$(tput sgr0)" >&2
 fi
 
 # Silence Docker emulation messages

--- a/shared/bin/publish.sh
+++ b/shared/bin/publish.sh
@@ -105,20 +105,29 @@ shift $((OPTIND - 1))
 # Check Docker file
 [[ -z $dockerfile ]] && err "You must provide a Docker file." && exit 2
 
+# Check if podman or docker is present
+if [[ $(docker --version 2> /dev/null) =~ Docker ]]; then
+   container_binary=docker
+   is_podman=false
+elif [[ $(podman --version 2> /dev/null) =~ podman ]]; then
+   container_binary=podman
+   is_podman=true
+else
+   err 'This script requires either Docker or Podman. Aborting.'
+   ext 1
+fi
+
 # Check dependencies, and abort if any are missing
-for c in tput realpath dirname basename docker jq; do
+for c in tput realpath dirname basename "$container_binary" jq; do
    if ! which "$c" &>/dev/null; then
       err "The $ul$c$rmul command is required by this script. Aborting."
       exit 1
    fi
 done
 
-# Detect podman
-[[ $(docker --version) == podman* ]] && is_podman=true || is_podman=false
-
 # Check arch... when running as podman, only support native arch.
 # Get arch info from docker/podman itself. Sadly, they report that info differently.
-docker_info=$(docker info -f json)
+docker_info=$("$container_binary" info -f json)
 native_arch=$(jq -r '.OSType' <<< "$docker_info")/$(jq -r '.Architecture' <<< "$docker_info")
 $is_podman && native_arch=$(jq -r '.host.os' <<< "$docker_info")/$(jq -r '.host.arch' <<< "$docker_info")
 if $is_podman && [[ $arches != "$native_arch" ]]; then
@@ -179,6 +188,7 @@ if $verbose; then
    echo
    echo "${bold}${ul}Building $img$norm"
    echo
+   echo "${bold}Container Tool:$norm $container_binary"
    [[ -n $builder ]] && echo "${bold}Builder:$norm $builder"
    echo "${bold}Dockerfile:$norm $dockerfile"
    echo "${bold}Context:$norm $context"
@@ -200,7 +210,7 @@ fi
 
 # Build images and push them to the registry
 $push && ! $is_podman && push_param=--push
-exec_cmd "docker build \
+exec_cmd "$container_binary build \
    -f $dockerfile \
    --platform $arches \
    $(for tag in "${tags[@]}"; do echo -n "-t $tag "; done) \
@@ -211,7 +221,7 @@ exec_cmd "docker build \
 
 # In podman, we have to push the tags after building
 $is_podman && $push && for tag in "${tags[@]}"; do
-   exec_cmd "docker push $tag"
+   exec_cmd "podman push $tag"
 done
 
 # Stop builder when done (not needed for podman)

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -21,23 +21,27 @@ Docker environment, making it easy to monitor and configure your Docker services
 
 ### How do I install the stacks without running the whole setup?
 
-You can run `./stacks/setup.sh` to just install the stacks, or run an individual stack's
-install script directly, such as `./stacks/nginx-proxy-manager-install.sh`.
+You can run the installer and specify just to install the stacks, like this:
+
+```bash
+bash <(curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/main/init.sh) --stacks-only
+```
+
+If you have downloaded or cloned the project, you can also run `./stacks/setup.sh`
+directly, to just install the stacks, or run an individual stack's install script
+directly, such as `./stacks/nginx-proxy-manager-install.sh`.
 
 ### How do I update the stacks with the latest version?
 
-First, ensure your `docker-host` instance is using the latest code by navigating to its
-directory and running `git pull`.
-
-For minor version bumps, you can stop the stack and reinstall it with the installer script
-and the `--upgrade` flag. This is not destructive; it will create containers using the
+To do this, you must download or clone the project and run the stack's installer directly,
+and add the `--upgrade` flag. This is not destructive; it will create containers using the
 same data/volumes you had already set up.
 
 #### Example: Stopping the stack
 
 ```bash
 # On a Docker host, just use docker compose:
-docker compose -f stacks/nginx-proxy-manager.yml down
+docker compose -f /etc/nginxproxymanager/nginx-proxy-manager.yml down
 # On a Podman host, you should use systemctl:
 systemctl stop nginxproxymanager
 ```

--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -7,24 +7,36 @@ echo "$(tput bold)
 #
 $(tput sgr0)"
 sleep 2
-scr_dir="${0%/*}"
-sec_dir="$scr_dir/../secrets"
-yml_file="$scr_dir/nginx-proxy-manager.yml"
+scr_dir=$(realpath "$(dirname "$0")")
+[[ -z $DEV ]] && DEV=false
+
+# Determine target directory and install
+target_dir=/etc/nginxproxymanager
+[[ "$(uname)" == "Darwin" || $EUID -ne 0 ]] && target_dir=$HOME/.nginxproxymanager
+$DEV && target_dir=$scr_dir
+sec_dir="$target_dir/secrets"
+yml_file="$target_dir/nginx-proxy-manager.yml"
+if ! $DEV; then
+   install -d "$sec_dir"
+   install -b "$scr_dir/nginx-proxy-manager.yml" "$yml_file"
+fi
 [[ $* == -u || $* == --upgrade ]] && upgrade_args=(--pull always)
-mkdir -p "$sec_dir"
 # Set up common "frontend" network shared among containers
 [ -z "$(docker network ls -qf name=frontend)" ] && docker network create frontend
 # Secrets for the passwords
-[ ! -f "$sec_dir/nginxproxymanager_db_password.txt" ] && openssl rand -hex 32 > "$sec_dir/nginxproxymanager_db_password.txt"
-[ ! -f "$sec_dir/nginxproxymanager_db_root_password.txt" ] && openssl rand -hex 32 > "$sec_dir/nginxproxymanager_db_root_password.txt"
+[ ! -f "$sec_dir/db_password.txt" ] && openssl rand -hex 32 > "$sec_dir/db_password.txt"
+[ ! -f "$sec_dir/db_root_password.txt" ] && openssl rand -hex 32 > "$sec_dir/db_root_password.txt"
 # If we're using podman, create the pod and include the podman arguments
 svc_name="nginxproxymanager"
-if [[ $(docker --version) == podman* ]]; then
-   podman pod create --name "$svc_name"
-   podman-compose --in-pod "$svc_name" --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
-else
-   docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
-fi
+(
+   cd "$target_dir" || exit 1
+   if [[ $(podman --version 2>/dev/null) == podman* ]]; then
+      podman pod create --name "$svc_name"
+      podman-compose --in-pod "$svc_name" --podman-run-args "${upgrade_args[*]}" -f "$yml_file" up -d
+   else
+      docker compose -f "$yml_file" up -d "${upgrade_args[@]}"
+   fi
+)
 # If we're using podman and `podman-install-service` is available, create the systemd service
 command -v podman-install-service &> /dev/null && podman-install-service "$svc_name"
 echo Done installing Nginx Proxy Manager!

--- a/stacks/nginx-proxy-manager.yml
+++ b/stacks/nginx-proxy-manager.yml
@@ -6,10 +6,10 @@ networks:
    backend:
 
 secrets:
-   nginxproxymanager_db_password:
-      file: ../secrets/nginxproxymanager_db_password.txt
-   nginxproxymanager_db_root_password:
-      file: ../secrets/nginxproxymanager_db_root_password.txt
+   db_password:
+      file: ./secrets/db_password.txt
+   db_root_password:
+      file: ./secrets/db_root_password.txt
 
 services:
 
@@ -27,13 +27,13 @@ services:
          DB_MYSQL_HOST: 'db'
          DB_MYSQL_PORT: 3306
          DB_MYSQL_USER: 'npm'
-         DB_MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
+         DB_MYSQL_PASSWORD__FILE: /run/secrets/db_password
          DB_MYSQL_NAME: 'npm'
       volumes:
          - 'data:/data'
          - 'letsencrypt:/etc/letsencrypt'
       secrets:
-         - nginxproxymanager_db_password
+         - db_password
       networks:
          - frontend
          - backend
@@ -43,15 +43,15 @@ services:
       privileged: true
       restart: unless-stopped
       environment:
-         MYSQL_ROOT_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_root_password
+         MYSQL_ROOT_PASSWORD__FILE: /run/secrets/db_root_password
          MYSQL_DATABASE: 'npm'
          MYSQL_USER: 'npm'
-         MYSQL_PASSWORD__FILE: /run/secrets/nginxproxymanager_db_password
+         MYSQL_PASSWORD__FILE: /run/secrets/db_password
       volumes:
          - 'db:/var/lib/mysql'
       secrets:
-         - nginxproxymanager_db_password
-         - nginxproxymanager_db_root_password
+         - db_password
+         - db_root_password
       networks:
          - backend
 

--- a/stacks/portainer-install.sh
+++ b/stacks/portainer-install.sh
@@ -7,8 +7,18 @@ echo "$(tput bold)
 #
 $(tput sgr0)"
 sleep 2
-scr_dir="${0%/*}"
-yml_file="$scr_dir/portainer.yml"
+scr_dir=$(realpath "$(dirname "$0")")
+[[ -z $DEV ]] && DEV=false
+
+# Determine target directory and install
+target_dir=/etc/portainer
+[[ "$(uname)" == "Darwin" || $EUID -ne 0 ]] && target_dir=$HOME/.portainer
+$DEV && target_dir=$scr_dir
+yml_file="$target_dir/portainer.yml"
+if ! $DEV; then
+   install -d "$target_dir"
+   install -b "$scr_dir/portainer.yml" "$yml_file"
+fi
 [[ $* == -u || $* == --upgrade ]] && upgrade_args=(--pull always)
 # Start the stack
 svc_name="portainer"

--- a/stacks/setup.sh
+++ b/stacks/setup.sh
@@ -2,43 +2,6 @@
 
 scr_dir="${0%/*}"
 
-# Collect user groups. We do this in the background right away since a server connected to AD may take
-# several seconds to respond with the group list.
-real_user=${SUDO_USER:-$(whoami)}
-groups_file=$(mktemp)
-(id "$real_user" | cut -d'=' -f4 | tr ',' '\n' > "$groups_file") &
-groups_pid="$!"
-
-# Create secrets directory
-sec_dir=$(realpath "$scr_dir/..")/secrets
-mkdir -p "$sec_dir"
-
-# Set strict permissions for the secrets
-echo "It is highly recommended that you restrict permissions of the $(tput smul)$(basename "$sec_dir")$(tput rmul) directory."
-echo "I can set the group to something your $real_user user also has access to."
-read -r -p "Do you want to do this? [Y/n] " yorn
-if [[ ${yorn:-y} =~ [Yy] ]]; then
-   echo -n "Great! Finding your user groups."
-   while ps "$groups_pid" > /dev/null; do echo -n '.'; sleep 1; done
-   echo -e '\n'
-   while IFS=$'\n' read -r line; do
-      group_array+=("$line")
-   done <<< "$(<"$groups_file")"
-   PS3="Either enter a number or manually type a group name: "
-   select group in "${group_array[@]}"; do
-      # Accept either the selected group or the manually-entered group
-      group=${group:-$REPLY}
-      # Don't accept a blank entry
-      [[ -n $group ]] && break
-   done
-   echo "Setting the group of the $(tput smul)$(basename "$sec_dir")$(tput rmul) directory to $(tput smul)$group$(tput rmul)."
-   # Groups will look like "123(group_name)", so we get just the number by looking to the left of '('.
-   # This will also work with manually entered groups like "group_name" or "123".
-   group=$(echo "$group" | cut -d'(' -f1)
-   chgrp -R "$group" "$sec_dir"
-   chmod -R 770 "$sec_dir"
-fi
-
 # Install individual stacks
 for stackinstaller in "$scr_dir"/*-install.sh; do
    stackname="$(basename "$stackinstaller" | sed -e "s/-install.sh//")"

--- a/ubuntu-22/docker.sh
+++ b/ubuntu-22/docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 scr_dir=$(realpath "${0%/*}")
+[[ -z $DEV ]] && DEV=false
 
 SCRIPT_TITLE="Install Docker"
 if [[ " $* " == *" --title "* ]]; then echo "$SCRIPT_TITLE"; exit 0; fi
@@ -22,15 +23,21 @@ apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Add scripts to /usr/bin so it will be in the path
-if [ -d '/usr/bin' ]; then
-   bin_dir='/usr/bin'
-elif [ -d '/usr/local/bin' ]; then
-   bin_dir='/usr/local/bin'
+if [[ -d /usr/bin ]]; then
+   bin_dir=/usr/bin
+elif [[ -d /usr/local/bin ]]; then
+   bin_dir=/usr/local/bin
 fi
-if [ -n "$bin_dir" ]; then
+if [[ -n $bin_dir ]]; then
+   echo "Installing scripts to $(tput smul)$bin_dir$(tput rmul) (may require a password):"
    for scr_name in "$scr_dir"/../shared/bin/*.sh; do
-      ln -f -s "$(realpath "$scr_name")" "$bin_dir/$(basename "$scr_name" .sh)"
+      cmd=(install -b -v) && $DEV && cmd=(ln -f -v -s)
+      cmd+=("$(realpath "$scr_name")")
+      cmd+=("$bin_dir/$(basename "$scr_name" .sh)")
+      "${cmd[@]}"
    done
+else
+   echo "$(tput setaf 1)Cannot install scripts to $(tput smul)$bin_dir$(tput rmul) because it wasn't found.$(tput sgr0)" >&2
 fi
 
 echo Done installing Docker!


### PR DESCRIPTION
The improvements in this PR focus around adjusting our project to be an ephemeral installer, rather than a cloned project that permanently resides somewhere on the system.

Obviously, this means any pertinent code that is required for execution must be installed somewhere. So, for stacks, their compose files are general stored in `/etc/stackname` along with any other configuration they may keep. Additional scripts are stored in `/usr/bin` on Linux systems and `/usr/local/bin` on macOS systems.

- Scripts were modified to report their version/build. This is important once they've been installed on a system so we can know what version we're dealing with.
- Scripts are installed at `/usr/bin` or `/usr/local/bin` and stacks are installed at `/etc/stackname`.
- When "dev mode" is used, stacks will be created from the compose files in the project directory, and symlinks will be installed in `/usr/bin` or `/usr/local/bin`. This is similar to previous behavior, and is handy for actual development of the docker-host project.

Additional important improvements:
- Eliminated the need for a `docker` shim in Podman installations. Scripts would use the commands `docker` and `docker-compose` even on Podman installations, just expecting shims to be present to run `podman` and `podman-compose`. Now, the scripts intelligently differentiate between docker and podman.

## Testing

To test, preferably use a fresh OS and run the installer from this branch, like this:

```bash
bash <(curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/jcurt/podman-and-ephemeral-installer/init.sh) -b jcurt/podman-and-ephemeral-installer
```

## Docs

For your convenience, here is a copy of the help screen of the main init.sh script:

```
   ___             __               __ __           __ 
  / _ \ ___  ____ / /__ ___  ____  / // /___   ___ / /_
 / // // _ \/ __//  '_// -_)/ __/ / _  // _ \ (_-</ __/
/____/ \___/\__//_/\_\ \__//_/   /_//_/ \___//___/\__/ 

Containerization on UIC Pharmacy servers (v1.0.0 build 5854dd31)

Usage: ./init.sh [OPTIONS]

Sets up an OS for container tooling and installs additional useful scripts for
container management according to UIC Pharmacy standards:

   - deploy: Helps deploy a stack.
   - publish: Takes a Dockerfile and publishes multi-arch images.
   - podman-install-service: Installs a Podman pod as a service.

Options:
-h, --help         Show this help message and exit.
-d, --dev          Install in developer mode, just create a symlink.
-b, --branch       Branch to use for installation files.
    --stacks-only  Only run the stack installation.
    --runner-only  Only run the GitHub Actions runner installation.
-V, --version      Print version and exit.
```

