### PR TITLE
Fix "secrets" directory creation in Nginx Proxy Manager installer

### DIFF
--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -16,8 +16,8 @@ target_dir=/etc/nginxproxymanager
 $DEV && target_dir=$scr_dir
 sec_dir="$target_dir/secrets"
 yml_file="$target_dir/nginx-proxy-manager.yml"
+install -d "$sec_dir"
 if ! $DEV; then
-   install -d "$sec_dir"
    install -b "$scr_dir/nginx-proxy-manager.yml" "$yml_file"
 fi
 [[ $* == -u || $* == --upgrade ]] && upgrade_args=(--pull always)


### PR DESCRIPTION
When recently reinstalling Nginx Proxy Manager on one of my workstations, I decided to run it in dev mode to keep it local to my project, and I discovered that it crashed because of the "secrets" directory missing. 

I discovered we should be creating the "secrets" directory regardless of dev install or not. This just fixes that.
