### PR TITLE
Fix build hash inconsistency

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -37,8 +37,14 @@ function yorn() {
 
 function display_version() {
    echo -n "Docker Host version $version build "
-   find "$dir" -type f \( -name '*.sh' -o -name '*.yml' \) -not -path '*/node_modules/*' | \
-   sort | xargs cat | sha256sum | cut -c1-8
+   # To calculate a build hash, we hash all of the sorted files according to these rules:
+   # - Exclude node_modules, exp, and hidden files/directories (using -prune)
+   # - Include symlinks, both files (-type f and -type l) and directories (-L)
+   # - Include only .sh and .yml files
+   find -L "$dir" \
+      \( -path '*/node_modules' -o -path '*/exp' -o -path '*/.*' \) -prune -o \
+      \( \( -type f -o -type l \) -a \( -name '*.sh' -o -name '*.yml' \) \) -print0 | \
+      LC_ALL=C sort -z | xargs -0 cat | sha256sum | cut -c1-8
 }
 
 # Title for the script


### PR DESCRIPTION
This bug doesn't actually impact behavior, but negates the purpose of the build hash. Due to inconsistencies with the way sorting occurs on different systems, the build hash may differ between systems.

To fix this, we use `LC_ALL=C` which consistently sorts files on all systems regardless of their locale, which influences the sorting algorithm.

While looking at the code, though, I realized that we were (a) Including some code that isn't "live" to the installer, like the `exp` and `.github` directories, and (b) NOT including symlinked directories and files, which could potentially result in the hash not changing when symlinked directories and files are added or omitted.

To demonstrate what files will be included in the hash calculation now, run this script from the `docker-host` project checkout:

```sh
dir=$(pwd); find -L "$dir" \
      \( -path '*/node_modules' -o -path '*/exp' -o -path '*/.*' \) -prune -o \
      \( \( -type f -o -type l \) -a \( -name '*.sh' -o -name '*.yml' \) \) -print0 | \
      LC_ALL=C sort -z|while IFS= read -r -d '' file; do; echo ${file/$dir\//}; done
```

It should return:
```
init.sh
macos/1-prep.sh
macos/2-docker.sh
macos/3-ghcr-auth.sh
macos/4-stacks.sh
macos/docker.sh
macos/prep.sh
macos/setup-shared.sh
macos/setup.sh
rhel-9/1-prep.sh
rhel-9/2-docker.sh
rhel-9/3-ghcr-auth.sh
rhel-9/4-stacks.sh
rhel-9/5-github-actions-runner.sh
rhel-9/bin/podman-install-service.sh
rhel-9/docker.sh
rhel-9/prep.sh
rhel-9/setup-shared.sh
rhel-9/setup.sh
rocky-9/1-prep.sh
rocky-9/2-docker.sh
rocky-9/3-ghcr-auth.sh
rocky-9/4-stacks.sh
rocky-9/5-github-actions-runner.sh
rocky-9/bin/podman-install-service.sh
rocky-9/docker.sh
rocky-9/prep.sh
rocky-9/setup-shared.sh
rocky-9/setup.sh
shared/bin/deploy.sh
shared/bin/publish.sh
shared/ghcr-auth.sh
shared/github-actions-runner.sh
shared/setup.sh
shared/stacks.sh
stacks/nginx-proxy-manager-install.sh
stacks/nginx-proxy-manager.yml
stacks/portainer-install.sh
stacks/portainer.yml
stacks/setup.sh
ubuntu-22/1-prep.sh
ubuntu-22/2-docker.sh
ubuntu-22/3-ghcr-auth.sh
ubuntu-22/4-stacks.sh
ubuntu-22/5-github-actions-runner.sh
ubuntu-22/docker.sh
ubuntu-22/prep.sh
ubuntu-22/setup-shared.sh
ubuntu-22/setup.sh
ubuntu-24/1-prep.sh
ubuntu-24/2-docker.sh
ubuntu-24/3-ghcr-auth.sh
ubuntu-24/4-stacks.sh
ubuntu-24/5-github-actions-runner.sh
ubuntu-24/docker.sh
ubuntu-24/prep.sh
ubuntu-24/setup-shared.sh
ubuntu-24/setup.sh
```

You can also test this on other systems by asking for the version from this branch like this:

```sh
 bash <(curl -H 'Cache-Control: no-cache, no-store' -o- https://raw.githubusercontent.com/uicpharm/docker-host/jcurt/hash/init.sh) -b jcurt/hash --version
```

Currently, it reports: `Docker Host version 1.0.0 build 4036ef92`