### PR TITLE
Nginx Proxy Manager custom directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .git
 .vscode
 node_modules
+custom
 secrets
 *.env

--- a/stacks/nginx-proxy-manager-install.sh
+++ b/stacks/nginx-proxy-manager-install.sh
@@ -14,9 +14,11 @@ scr_dir=$(realpath "$(dirname "$0")")
 target_dir=/etc/nginxproxymanager
 [[ "$(uname)" == "Darwin" || $EUID -ne 0 ]] && target_dir=$HOME/.nginxproxymanager
 $DEV && target_dir=$scr_dir
+custom_dir="$target_dir/custom"
 sec_dir="$target_dir/secrets"
 yml_file="$target_dir/nginx-proxy-manager.yml"
 install -d "$sec_dir"
+install -d "$custom_dir"
 if ! $DEV; then
    install -b "$scr_dir/nginx-proxy-manager.yml" "$yml_file"
 fi

--- a/stacks/nginx-proxy-manager.yml
+++ b/stacks/nginx-proxy-manager.yml
@@ -32,6 +32,7 @@ services:
       volumes:
          - 'data:/data'
          - 'letsencrypt:/etc/letsencrypt'
+         - './custom:/var/www/custom'
       secrets:
          - db_password
       networks:


### PR DESCRIPTION
This improvement adds a mapping from `custom` to `/var/www/custom` within the Nginx Proxy Manager container. This can then be used to store any type of custom configuration or content that NPM needs, but in a way that can be consistent across our servers. If it isn't needed, it can be ignored. If it is needed, a proxy host's custom Nginx configuration can reference any files placed here.